### PR TITLE
Chore: version bump (bevy_egui, bevy_pancam)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ bevy = { version = "0.10", default-features = false, features = [
   "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 rand = "0.8"
-# bevy_egui = {version = "0.17", default-features = false, features = ["default_fonts"]}
-bevy_egui = {git = "https://github.com/mvlabat/bevy_egui", branch = "bevy-0.10", default-features = false, features = ["default_fonts"]}
+bevy_egui = {version = "0.20.1", default-features = false, features = ["default_fonts"]}
+# bevy_egui = {git = "https://github.com/mvlabat/bevy_egui", branch = "bevy-0.10", default-features = false, features = ["default_fonts"]}
 # bevy-inspector-egui = {version = "0.14", default-features = false}
-# bevy_pancam = { version = "0.7", features = ["bevy-inspector-egui", "bevy_egui"] }
-bevy_pancam = { git = "https://github.com/johanhelsing/bevy_pancam", branch = "bevy-0.10", features = ["bevy_egui"] }
+bevy_pancam = {version = "0.8", features = ["bevy_egui"] }
+# bevy_pancam = { git = "https://github.com/johanhelsing/bevy_pancam", branch = "bevy-0.10", features = ["bevy_egui"] }
 insta = "1.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ bevy = { version = "0.10", default-features = false, features = [
 ] }
 rand = "0.8"
 bevy_egui = {version = "0.20.1", default-features = false, features = ["default_fonts"]}
-# bevy_egui = {git = "https://github.com/mvlabat/bevy_egui", branch = "bevy-0.10", default-features = false, features = ["default_fonts"]}
-# bevy-inspector-egui = {version = "0.14", default-features = false}
+bevy-inspector-egui = {version = "0.18.1", default-features = false}
 bevy_pancam = {version = "0.8", features = ["bevy_egui"] }
-# bevy_pancam = { git = "https://github.com/johanhelsing/bevy_pancam", branch = "bevy-0.10", features = ["bevy_egui"] }
 insta = "1.21"

--- a/examples/asteroids.rs
+++ b/examples/asteroids.rs
@@ -5,7 +5,7 @@ use bevy::{
     render::{camera::ScalingMode, render_resource::AsBindGroup},
     sprite::{Material2d, Material2dPlugin, MaterialMesh2dBundle},
 };
-// use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_pancam::{PanCam, PanCamPlugin};
 use noisy_bevy::{simplex_noise_2d_seeded, NoisyShaderPlugin};
 
@@ -20,7 +20,7 @@ fn main() {
         .add_plugin(NoisyShaderPlugin)
         .add_plugin(PanCamPlugin::default())
         .add_plugin(Material2dPlugin::<AsteroidBackgroundMaterial>::default())
-        // .add_plugin(WorldInspectorPlugin::default())
+        .add_plugin(WorldInspectorPlugin::new())
         .add_startup_system(setup)
         .add_system(expand_asteroids)
         .run();


### PR DESCRIPTION
It's possible this PR introduces regressions with bevy_egui and some visual regressions when running the asteroids example. I've attached some comparison images of what I'm expecting vs. the results I see when running the example.

Expecting
![68747470733a2f2f73332e6a6f68616e68656c73696e672e73747564696f2f64756d702f6e6f6973795f61737465726f69642e706e67](https://user-images.githubusercontent.com/5461576/227057361-77242f30-c6d5-4e76-a9dd-97f435ff0afe.png)

Results
<img width="955" alt="Screenshot 2023-03-22 140303" src="https://user-images.githubusercontent.com/5461576/227057396-71cf5a41-8b7b-4a6b-ab56-6c4adbe80b17.png">
