### PR TITLE
Update to bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,20 @@ repository = "https://github.com/johanhelsing/noisy_bevy"
 version = "0.5.0"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = [
-  "bevy_asset",
-  "bevy_render"
- ] }
+bevy = { version = "0.13", default-features = false, features = [
+    "bevy_asset",
+    "bevy_render"
+] }
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = false, features = [
-  "bevy_sprite",
-  "bevy_winit",
-  "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
+bevy = { version = "0.13", default-features = false, features = [
+    "bevy_sprite",
+    "bevy_winit",
+    "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 rand = "0.8"
-bevy_egui = { version = "0.23", default-features = false, features = ["default_fonts"] }
-# bevy-inspector-egui = {version = "0.19.1", default-features = false}
-bevy_pancam = { version = "0.10", features = ["bevy_egui"] }
+bevy_egui = { version = "0.25", default-features = false, features = ["default_fonts"] }
+# TODO: Change back to crates.io version once bevy_pancam 0.11 is released (https://github.com/johanhelsing/bevy_pancam/pull/56):
+#       bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
+bevy_pancam = { git = "https://github.com/tomara-x/bevy_pancam.git", branch = "main", features = ["bevy_egui"] }
 insta = "1.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,5 @@ bevy = { version = "0.13", default-features = false, features = [
 ] }
 rand = "0.8"
 bevy_egui = { version = "0.25", default-features = false, features = ["default_fonts"] }
-# TODO: Change back to crates.io version once bevy_pancam 0.11 is released (https://github.com/johanhelsing/bevy_pancam/pull/56):
-#       bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
-bevy_pancam = { git = "https://github.com/tomara-x/bevy_pancam.git", branch = "main", features = ["bevy_egui"] }
+bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
 insta = "1.21"

--- a/assets/examples/asteroid_background.wgsl
+++ b/assets/examples/asteroid_background.wgsl
@@ -8,7 +8,7 @@ struct AsteroidMaterial {
     params: vec4<f32>
 }
 
-@group(1) @binding(0) var<uniform> material: AsteroidMaterial;
+@group(2) @binding(0) var<uniform> material: AsteroidMaterial;
 
 struct Vertex {
     @builtin(instance_index) instance_index: u32,

--- a/examples/asteroids.rs
+++ b/examples/asteroids.rs
@@ -139,7 +139,7 @@ fn expand_asteroids(
                 ),
             });
 
-            let quad_handle = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(100.0, 100.0))));
+            let quad_handle = meshes.add(Mesh::from(Rectangle::from_size(Vec2::new(100.0, 100.0))));
 
             asteroid.spawn(MaterialMesh2dBundle {
                 mesh: quad_handle.into(),


### PR DESCRIPTION
Updates bevy, bevy_egui, and bevy_pancam dependencies for bevy 0.13.

Also fixes the asteroids example, whose shader was broken by bevy 0.13 [rearranging bind groups](https://bevyengine.org/news/bevy-0-13/#wgpu-0-19-upgrade-and-rendering-performance-improvements).

Note: This is a draft because bevy_pancam doesn't yet support bevy 0.13, though [bevy_pancam#56](https://github.com/johanhelsing/bevy_pancam/pull/56) will fix this. For the time being, I've swapped in that PR's github link for the bevy_pancam dependency.