### PR TITLE
Update readme code examples for newer Bevy versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ First add the plugin to the Bevy app:
 
 ```rust ignore
 App::new()
-    .add_plugin(NoisyShaderPlugin)
+    .add_plugins(NoisyShaderPlugin)
 ```
 
 And import it and use it in your shaders, with the same API as on the CPU-side:
 
 ```wgsl
-#import noisy_bevy simplex_noise_2d
+#import noisy_bevy::simplex_noise_2d
 
 // ...
 


### PR DESCRIPTION
Some of the README code examples are for older versions of bevy:
- `add plugin` doesn't exist anymore
- `#import noisy_bevy simplex_noise_2d` gives a warning 