### PR TITLE
Fixed artifacts on the diagonals

### DIFF
--- a/assets/noisy_bevy.wgsl
+++ b/assets/noisy_bevy.wgsl
@@ -6,6 +6,11 @@ fn permute_3_(x: vec3<f32>) -> vec3<f32> {
     return (((x * 34.) + 1.) * x) % vec3(289.);
 }
 
+fn step_3(edge: vec3<f32>, x: vec3<f32>) -> vec3<f32> {
+    let b = vec3(edge.x < x.x, edge.y <= x.y, edge.z <= x.z);
+    return select(vec3(0.), vec3(1.), b);
+}
+
 fn simplex_noise_2d(v: vec2<f32>) -> f32 {
     let C = vec4(
         0.211324865405187, // (3.0 - sqrt(3.0)) / 6.0
@@ -104,7 +109,7 @@ fn simplex_noise_3d(v: vec3<f32>) -> f32 {
     let x0 = v - i + dot(i, C.xxx);
 
     // other corners
-    let g = step(x0.yzx, x0.xyz);
+    let g = step_3(x0.yzx, x0.xyz);
     let l = 1. - g;
     let i1 = min(g.xyz, l.zxy);
     let i2 = max(g.xyz, l.zxy);
@@ -173,7 +178,7 @@ fn simplex_noise_3d_seeded(v: vec3<f32>, seed: vec3<f32>) -> f32 {
     let x0 = v - i + dot(i, C.xxx);
 
     // other corners
-    let g = step(x0.yzx, x0.xyz);
+    let g = step_3(x0.yzx, x0.xyz);
     let l = 1. - g;
     let i1 = min(g.xyz, l.zxy);
     let i2 = max(g.xyz, l.zxy);
@@ -288,7 +293,7 @@ fn fbm_simplex_2d_warp_seeded(pos_initial: vec2<f32>, octaves: i32, lacunarity: 
     for (var i: i32 = 0; i < iterations; i++) {
         pos.x += scale * warp_scale.x * fbm_simplex_2d_seeded(pos, octaves, lacunarity, gain, seed);
         pos.y += scale * warp_scale.y * fbm_simplex_2d_seeded(pos, octaves, lacunarity, gain, seed);
-        
+
         // Store positions in reverse order for easier user access (last iteration at index 0)
         let index = max_warp_iterations - 1 - i;
         if (index < max_warp_iterations) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ fn step_4(edge: Vec4, x: Vec4) -> Vec4 {
 
 #[inline]
 fn step_3(edge: Vec3, x: Vec3) -> Vec3 {
-    let b = Vec3::cmple(edge, x);
+    let b = bvec3(edge.x < x.x, edge.y <= x.y, edge.z <= x.z);
     Vec3::select(b, Vec3::ONE, Vec3::ZERO)
 }
 


### PR DESCRIPTION
There were artifacts in the 3d simplex noise functions on the diagonals x=y=z mod 1 (or mod whichever lattice's cells we're cutting into simplices). I broke the ties by using < instead of <= in one component of step_3. I do not have a test case showing the problem, but I can vouch that there were discontinuities before, and this change got rid of them.