### PR TITLE
Bevy subcrates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ repository = "https://github.com/johanhelsing/noisy_bevy"
 version = "0.13.0"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.18", default-features = false, optional = true }
+bevy_shader = { version = "0.18", default-features = false, optional = true }
+bevy_app = { version = "0.18", default-features = false, optional = true }
+glam = { version = "0.30", default-features = false, features = ["bytemuck"], optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.18", default-features = false, features = [
@@ -33,9 +36,12 @@ default = [
 ]
 
 gpu = [
-    "bevy/bevy_asset",
-    "bevy/bevy_shader",
+    "dep:bevy_app",
+    "dep:bevy_asset",
+    "dep:bevy_shader",
 ]
 
-cpu = []
+cpu = [
+    "dep:glam",
+]
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,4 +1,4 @@
-use bevy::math::{Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles, vec2, vec3, vec4};
+use glam::{Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles, vec2, vec3, vec4};
 
 fn permute_3(x: Vec3) -> Vec3 {
     (((x * 34.) + 1.) * x) % Vec3::splat(289.)

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,8 +1,6 @@
-use bevy::{
-    app::{ Plugin, App },
-    asset::{ Handle, load_internal_asset, uuid_handle },
-    shader::{ Shader },
-};
+use bevy_app::{ Plugin, App };
+use bevy_asset::{ Handle, load_internal_asset, uuid_handle };
+use bevy_shader::{ Shader };
 
 /// Adds noise library as a wgsl import
 ///


### PR DESCRIPTION
(Draft WIP) This relies on my other pr - #28

I split out the usage of the `bevy` dependency into the specific subcrates that the Bevy engine provides. This could in theory improve compile times in certain scenarios.

From discussion in my other PR:
> The main reason I've seen is better compile times. There are tradeoffs to each approach, but the consensus I've been seeing is libraries should move to the subcrates, especially when you could potentially use the library without bevy at all - in this case the CPU noise functions are not at all dependent on Bevy except for the vector types from bevy_math. There's a good discussion on the tradeoffs on the Discord server:
>
> https://discord.com/channels/691052431525675048/692572690833473578/1425929059195424831

Additionally I rely directly on `glam` instead of `bevy_math` so this crate and the `cpu` feature could be used in a context completely without `bevy`. I specifically didn't use the default features so it can also be used in no-std environments as well. I copied exactly the same feature usage that the `bevy_math` crate does (i.e. `bytemuck`).
